### PR TITLE
chore: set up secrets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+secrets/*
+!secrets/.gitkeep


### PR DESCRIPTION
This PR sets up the secrets folder for storing secrets and ignores all contents in it (except `.gitkeep` to make git track the folder).