### PR TITLE
chore: consistent base images and fix wrong data entry

### DIFF
--- a/src/construct-qa/Dockerfile
+++ b/src/construct-qa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 # Environment variabless
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/data-pipeline/Dockerfile
+++ b/src/data-pipeline/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 # Environment variables
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/data-pipeline/clean.py
+++ b/src/data-pipeline/clean.py
@@ -204,8 +204,8 @@ def clean_one_study(study):
     )
 
     # Inverventions module
-    interv_module = protocols.get("armsInterventionsModule", {})
-    cleaned_data["Interventions"] = [
+    interv_module = protocols.get("armssModule", {})
+    cleaned_data["interventions"] = [
         {
             "type": item.get("type"),
             "name": item.get("name"),

--- a/src/data-pipeline/clean.py
+++ b/src/data-pipeline/clean.py
@@ -204,7 +204,7 @@ def clean_one_study(study):
     )
 
     # Inverventions module
-    interv_module = protocols.get("armssModule", {})
+    interv_module = protocols.get("armsInterventionsModule", {})
     cleaned_data["interventions"] = [
         {
             "type": item.get("type"),

--- a/src/embedding-model/Dockerfile
+++ b/src/embedding-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 # Environment variabless
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/finetune-model/Dockerfile
+++ b/src/finetune-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 # Environment variabless
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Bookworm is the current latest stable debian release. Previously buster was too old that did not work for the model embedding container so we upgraded to bullseye which is enough, but I believe having an up-to-date one is better here.