### PR TITLE
data-pipeline: fix typo in clean script

### DIFF
--- a/src/data-pipeline/clean.py
+++ b/src/data-pipeline/clean.py
@@ -40,7 +40,7 @@ _FIELDS = [
     "enrollment_count",  # int
     "allocation",  # str
     "intervention_model",  # str
-    "observation_model",  # str
+    "observational_model",  # str
     "primary_purpose",  # str
     "who_masked",  # str
     # Inverventions module
@@ -197,7 +197,7 @@ def clean_one_study(study):
     )
     cleaned_data["allocation"] = design_info.get("allocation")
     cleaned_data["intervention_model"] = design_info.get("interventionModel")
-    cleaned_data["observation_model"] = design_info.get("observationalModel")
+    cleaned_data["observational_model"] = design_info.get("observationalModel")
     cleaned_data["primary_purpose"] = design_info.get("primaryPurpose")
     cleaned_data["who_masked"] = (
         ", ".join(design_info.get("maskingInfo", {}).get("whoMasked", [])) or None


### PR DESCRIPTION
`observation_model` is a typo, which should be `observational_model`. The GCP bucket has already been updated. To keep in sync with the updated version, it suffices to go to `embedding-models`, then inside its docker container,delete the previous ChromaDB collection, and redo `python cli.py store`.