### PR TITLE
ci: configure dependabot to update app dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Node dependencies
+  - package-ecosystem: npm
+    directories:
+      - /app/frontend
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    groups:
+      all:
+        patterns:
+          - "*"
+
+  # Python dependencies
+  - package-ecosystem: pip
+    directories:
+      - /app/backend
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    groups:
+      all:
+        patterns:
+          - "*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,3 +31,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    labels:
+      - dependencies


### PR DESCRIPTION
This PR configures dependabot. The frequency is currently set to daily but after the semester we should set it to e.g. monthly or simply disable dependabot. Except from keeping things up-to-date, this is also trying to (hopefully) solve the issue of cross-platform `Pipfile.lock`.