### PR TITLE
ci: specify package versions in pipfile

### DIFF
--- a/app/backend/Pipfile
+++ b/app/backend/Pipfile
@@ -4,18 +4,18 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-chromadb-client = "*"
-fastapi = "*"
-FlagEmbedding = "*"
-google-cloud-aiplatform = "*"
-peft = "*"  # XXX: required by FlagEmbedding, but not in setup.py before 1.0.6
-typing-extensions = "*"
-uvicorn = "*"
+chromadb-client = "~=0.5.17"
+fastapi = "~=0.155.4"
+FlagEmbedding = "~=1.3.1"
+google-cloud-aiplatform = "~=1.71.0"
+peft = "~=0.13.1"  # XXX: required by FlagEmbedding, but not in setup.py before 1.0.6
+typing-extensions = "~=4.12.1"
+uvicorn = "~=0.31.0"
 
 [dev-packages]
-black = "*"
-mypy = "*"
-ruff = "*"
+black = "~=24.9.0"
+mypy = "~=1.12.0"
+ruff = "~=0.7.3"
 
 [requires]
 python_version = "3.11"


### PR DESCRIPTION
This is hoping that dependabot can do something to the lock file. All these versions specified in this PR are not latest stable versions.