### PR TITLE
ci: make dependabot update all (including indirect) dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,8 @@ updates:
       interval: daily
     labels:
       - dependencies
+    allow:
+      - dependency-type: all
     groups:
       all:
         patterns:

--- a/app/backend/Pipfile
+++ b/app/backend/Pipfile
@@ -4,18 +4,17 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-chromadb-client = "~=0.5.17"
-fastapi = "~=0.155.4"
-FlagEmbedding = "~=1.3.1"
-google-cloud-aiplatform = "~=1.71.0"
-peft = "~=0.13.1"  # XXX: required by FlagEmbedding, but not in setup.py before 1.0.6
-typing-extensions = "~=4.12.1"
-uvicorn = "~=0.31.0"
+chromadb-client = "*"
+fastapi = "*"
+FlagEmbedding = "*"
+google-cloud-aiplatform = "*"
+typing-extensions = "*"
+uvicorn = "*"
 
 [dev-packages]
-black = "~=24.9.0"
-mypy = "~=1.12.0"
-ruff = "~=0.7.3"
+black = "*"
+mypy = "*"
+ruff = "*"
 
 [requires]
 python_version = "3.11"

--- a/app/backend/Pipfile.lock
+++ b/app/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f90794246fc7eb24d2178eb9ddb9a8fbe8bef2bf06c81977b8ce9d538dd4fd12"
+            "sha256": "d71ad8c269eba7bd8c6937dfa611b22a0bc475711c35e68a1509ca644785a2f8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1385,51 +1385,51 @@
         },
         "opentelemetry-api": {
             "hashes": [
-                "sha256:6fa7295a12c707f5aebef82da3d9ec5afe6992f3e42bfe7bec0339a44b3518e7",
-                "sha256:bfe86c95576cf19a914497f439fd79c9553a38de0adbdc26f7cfc46b0c00b16c"
+                "sha256:6fcec89e265beb258fe6b1acaaa3c8c705a934bd977b9f534a2b7c0d2d4275a6",
+                "sha256:ecdc70c7139f17f9b0cf3742d57d7020e3e8315d6cffcdf1a12a905d45b19cc0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.28.1"
+            "version": "==1.28.2"
         },
         "opentelemetry-exporter-otlp-proto-common": {
             "hashes": [
-                "sha256:56ea6cf28c90f767733f046a54525dc7271a25faff86b1955e5252b55f4e007f",
-                "sha256:6e55e7f5d59296cc87a74c08b8e0ddf87403f73a62302ec7ee042c1a1f4a8f70"
+                "sha256:545b1943b574f666c35b3d6cc67cb0b111060727e93a1e2866e346b33bff2a12",
+                "sha256:7aebaa5fc9ff6029374546df1f3a62616fda07fccd9c6a8b7892ec130dd8baca"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.28.1"
+            "version": "==1.28.2"
         },
         "opentelemetry-exporter-otlp-proto-grpc": {
             "hashes": [
-                "sha256:9c84a103734d0c9cf9a4ba973d9c15c21996a554ab2bbd6208b3925873912642",
-                "sha256:fd494b9dd7869975138cef68d52ed45b9ca584c1fa31bef2d01ecfd537445dfa"
+                "sha256:07c10378380bbb01a7f621a5ce833fc1fab816e971140cd3ea1cd587840bc0e6",
+                "sha256:6083d9300863aab35bfce7c172d5fc1007686e6f8dff366eae460cd9a21592e2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.28.1"
+            "version": "==1.28.2"
         },
         "opentelemetry-proto": {
             "hashes": [
-                "sha256:6f9e9d9958822ab3e3cdcd2a24806d62aa10282349fd4338aafe32c69c87fc15",
-                "sha256:cb406ec69f1d11439e60fb43c6b744783fc8ee4deecdab61b3e29f112b0602f9"
+                "sha256:0837498f59db55086462915e5898d0b1a18c1392f6db4d7e937143072a72370c",
+                "sha256:7c0d125a6b71af88bfeeda16bfdd0ff63dc2cf0039baf6f49fa133b203e3f566"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.28.1"
+            "version": "==1.28.2"
         },
         "opentelemetry-sdk": {
             "hashes": [
-                "sha256:100fa371b2046ffba6a340c18f0b2a0463acad7461e5177e126693b613a6ca57",
-                "sha256:72aad7f5fcbe37113c4ab4899f6cdeb6ac77ed3e62f25a85e3627b12583dad0f"
+                "sha256:5fed24c5497e10df30282456fe2910f83377797511de07d14cec0d3e0a1a3110",
+                "sha256:93336c129556f1e3ccd21442b94d3521759541521861b2214c499571b85cb71b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.28.1"
+            "version": "==1.28.2"
         },
         "opentelemetry-semantic-conventions": {
             "hashes": [
-                "sha256:91817883b159ffb94c2ca9548509c4fe0aafce7c24f437aa6ac3fc613aa9a758",
-                "sha256:dd6f3ac8169d2198c752e1a63f827e5f5e110ae9b0ce33f2aad9a3baf0739743"
+                "sha256:44e32ce6a5bb8d7c0c617f84b9dc1c8deda1045a07dc16a688cc7cbeab679997",
+                "sha256:51e7e1d0daa958782b6c2a8ed05e5f0e7dd0716fc327ac058777b8659649ee54"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.49b1"
+            "version": "==0.49b2"
         },
         "orjson": {
             "hashes": [
@@ -1564,7 +1564,6 @@
                 "sha256:0e0cbd40ebdf5fe4ea79f255880d02f96712d18899509369a2cc5768ad46d672",
                 "sha256:d4e0951ec78eac11c45a051801c569913436888c578d48e5ce86996b715bc6ef"
             ],
-            "index": "pypi",
             "markers": "python_full_version >= '3.8.0'",
             "version": "==0.13.2"
         },
@@ -2362,11 +2361,11 @@
         },
         "sentence-transformers": {
             "hashes": [
-                "sha256:5897c376fde1fea5f22a90ead2612278a464e52b8e42f1af95f84092c36bc23c",
-                "sha256:b91f0aea4ada72ed5a7cdbe8a6245a7152d0d9f84f336383778f8568e406b008"
+                "sha256:9635dbfb11c6b01d036b9cfcee29f7716ab64cf2407ad9f403a2e607da2ac48b",
+                "sha256:abffcc79dab37b7d18d21a26d5914223dd42239cfe18cb5e111c66c54b658ae7"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "sentencepiece": {
             "hashes": [
@@ -2500,11 +2499,11 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62",
-                "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d"
+                "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835",
+                "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.41.2"
+            "version": "==0.41.3"
         },
         "sympy": {
             "hashes": [
@@ -2955,91 +2954,91 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:06157fb3c58f2736a5e47c8fcbe1afc8b5de6fb28b14d25574af9e62150fcaac",
-                "sha256:067a63fcfda82da6b198fa73079b1ca40b7c9b7994995b6ee38acda728b64d47",
-                "sha256:0b1794853124e2f663f0ea54efb0340b457f08d40a1cef78edfa086576179c91",
-                "sha256:0bdff5e0995522706c53078f531fb586f56de9c4c81c243865dd5c66c132c3b5",
-                "sha256:117ed8b3732528a1e41af3aa6d4e08483c2f0f2e3d3d7dca7cf538b3516d93df",
-                "sha256:14bc88baa44e1f84164a392827b5defb4fa8e56b93fecac3d15315e7c8e5d8b3",
-                "sha256:1654ec814b18be1af2c857aa9000de7a601400bd4c9ca24629b18486c2e35463",
-                "sha256:16bca6678a83657dd48df84b51bd56a6c6bd401853aef6d09dc2506a78484c7b",
-                "sha256:1a3b91c44efa29e6c8ef8a9a2b583347998e2ba52c5d8280dbd5919c02dfc3b5",
-                "sha256:1a52a1ffdd824fb1835272e125385c32fd8b17fbdefeedcb4d543cc23b332d74",
-                "sha256:1ce36ded585f45b1e9bb36d0ae94765c6608b43bd2e7f5f88079f7a85c61a4d3",
-                "sha256:299f11b44d8d3a588234adbe01112126010bd96d9139c3ba7b3badd9829261c3",
-                "sha256:2b24ec55fad43e476905eceaf14f41f6478780b870eda5d08b4d6de9a60b65b4",
-                "sha256:2d374d70fdc36f5863b84e54775452f68639bc862918602d028f89310a034ab0",
-                "sha256:2d9f0606baaec5dd54cb99667fcf85183a7477f3766fbddbe3f385e7fc253299",
-                "sha256:2e7ba4c9377e48fb7b20dedbd473cbcbc13e72e1826917c185157a137dac9df2",
-                "sha256:2f0a6423295a0d282d00e8701fe763eeefba8037e984ad5de44aa349002562ac",
-                "sha256:327828786da2006085a4d1feb2594de6f6d26f8af48b81eb1ae950c788d97f61",
-                "sha256:380e6c38ef692b8fd5a0f6d1fa8774d81ebc08cfbd624b1bca62a4d4af2f9931",
-                "sha256:3b74ff4767d3ef47ffe0cd1d89379dc4d828d4873e5528976ced3b44fe5b0a21",
-                "sha256:3e844be8d536afa129366d9af76ed7cb8dfefec99f5f1c9e4f8ae542279a6dc3",
-                "sha256:459e81c2fb920b5f5df744262d1498ec2c8081acdcfe18181da44c50f51312f7",
-                "sha256:46ddf6e0b975cd680eb83318aa1d321cb2bf8d288d50f1754526230fcf59ba96",
-                "sha256:482c122b72e3c5ec98f11457aeb436ae4aecca75de19b3d1de7cf88bc40db82f",
-                "sha256:561c87fea99545ef7d692403c110b2f99dced6dff93056d6e04384ad3bc46243",
-                "sha256:578d00c9b7fccfa1745a44f4eddfdc99d723d157dad26764538fbdda37209857",
-                "sha256:58c8e9620eb82a189c6c40cb6b59b4e35b2ee68b1f2afa6597732a2b467d7e8f",
-                "sha256:5b29beab10211a746f9846baa39275e80034e065460d99eb51e45c9a9495bcca",
-                "sha256:5d1d42556b063d579cae59e37a38c61f4402b47d70c29f0ef15cee1acaa64488",
-                "sha256:5f236cb5999ccd23a0ab1bd219cfe0ee3e1c1b65aaf6dd3320e972f7ec3a39da",
-                "sha256:62a91aefff3d11bf60e5956d340eb507a983a7ec802b19072bb989ce120cd948",
-                "sha256:64cc6e97f14cf8a275d79c5002281f3040c12e2e4220623b5759ea7f9868d6a5",
-                "sha256:6f4c9156c4d1eb490fe374fb294deeb7bc7eaccda50e23775b2354b6a6739934",
-                "sha256:7294e38f9aa2e9f05f765b28ffdc5d81378508ce6dadbe93f6d464a8c9594473",
-                "sha256:7615058aabad54416ddac99ade09a5510cf77039a3b903e94e8922f25ed203d7",
-                "sha256:7e48cdb8226644e2fbd0bdb0a0f87906a3db07087f4de77a1b1b1ccfd9e93685",
-                "sha256:7f63d176a81555984e91f2c84c2a574a61cab7111cc907e176f0f01538e9ff6e",
-                "sha256:7f6595c852ca544aaeeb32d357e62c9c780eac69dcd34e40cae7b55bc4fb1147",
-                "sha256:7fac95714b09da9278a0b52e492466f773cfe37651cf467a83a1b659be24bf71",
-                "sha256:81713b70bea5c1386dc2f32a8f0dab4148a2928c7495c808c541ee0aae614d67",
-                "sha256:846dd2e1243407133d3195d2d7e4ceefcaa5f5bf7278f0a9bda00967e6326b04",
-                "sha256:84c063af19ef5130084db70ada40ce63a84f6c1ef4d3dbc34e5e8c4febb20822",
-                "sha256:881764d610e3269964fc4bb3c19bb6fce55422828e152b885609ec176b41cf11",
-                "sha256:8994b29c462de9a8fce2d591028b986dbbe1b32f3ad600b2d3e1c482c93abad6",
-                "sha256:8c79e9d7e3d8a32d4824250a9c6401194fb4c2ad9a0cec8f6a96e09a582c2cc0",
-                "sha256:8ee427208c675f1b6e344a1f89376a9613fc30b52646a04ac0c1f6587c7e46ec",
-                "sha256:949681f68e0e3c25377462be4b658500e85ca24323d9619fdc41f68d46a1ffda",
-                "sha256:9e275792097c9f7e80741c36de3b61917aebecc08a67ae62899b074566ff8556",
-                "sha256:9fb815155aac6bfa8d86184079652c9715c812d506b22cfa369196ef4e99d1b4",
-                "sha256:a2a64e62c7a0edd07c1c917b0586655f3362d2c2d37d474db1a509efb96fea1c",
-                "sha256:a7ac5b4984c468ce4f4a553df281450df0a34aefae02e58d77a0847be8d1e11f",
-                "sha256:aa46dce75078fceaf7cecac5817422febb4355fbdda440db55206e3bd288cfb8",
-                "sha256:ae3476e934b9d714aa8000d2e4c01eb2590eee10b9d8cd03e7983ad65dfbfcba",
-                "sha256:b0341e6d9a0c0e3cdc65857ef518bb05b410dbd70d749a0d33ac0f39e81a4258",
-                "sha256:b40d1bf6e6f74f7c0a567a9e5e778bbd4699d1d3d2c0fe46f4b717eef9e96b95",
-                "sha256:b5c4804e4039f487e942c13381e6c27b4b4e66066d94ef1fae3f6ba8b953f383",
-                "sha256:b5d6a6c9602fd4598fa07e0389e19fe199ae96449008d8304bf5d47cb745462e",
-                "sha256:b5f1ac7359e17efe0b6e5fec21de34145caef22b260e978336f325d5c84e6938",
-                "sha256:c0167540094838ee9093ef6cc2c69d0074bbf84a432b4995835e8e5a0d984374",
-                "sha256:c180ac742a083e109c1a18151f4dd8675f32679985a1c750d2ff806796165b55",
-                "sha256:c73df5b6e8fabe2ddb74876fb82d9dd44cbace0ca12e8861ce9155ad3c886139",
-                "sha256:c7e177c619342e407415d4f35dec63d2d134d951e24b5166afcdfd1362828e17",
-                "sha256:cbad927ea8ed814622305d842c93412cb47bd39a496ed0f96bfd42b922b4a217",
-                "sha256:cc353841428d56b683a123a813e6a686e07026d6b1c5757970a877195f880c2d",
-                "sha256:cc7c92c1baa629cb03ecb0c3d12564f172218fb1739f54bf5f3881844daadc6d",
-                "sha256:cc7d768260f4ba4ea01741c1b5fe3d3a6c70eb91c87f4c8761bbcce5181beafe",
-                "sha256:d0eea830b591dbc68e030c86a9569826145df485b2b4554874b07fea1275a199",
-                "sha256:d216e5d9b8749563c7f2c6f7a0831057ec844c68b4c11cb10fc62d4fd373c26d",
-                "sha256:d401f07261dc5aa36c2e4efc308548f6ae943bfff20fcadb0a07517a26b196d8",
-                "sha256:d6324274b4e0e2fa1b3eccb25997b1c9ed134ff61d296448ab8269f5ac068c4c",
-                "sha256:d8a8b74d843c2638f3864a17d97a4acda58e40d3e44b6303b8cc3d3c44ae2d29",
-                "sha256:d9b6b28a57feb51605d6ae5e61a9044a31742db557a3b851a74c13bc61de5172",
-                "sha256:de599af166970d6a61accde358ec9ded821234cbbc8c6413acfec06056b8e860",
-                "sha256:e594b22688d5747b06e957f1ef822060cb5cb35b493066e33ceac0cf882188b7",
-                "sha256:e5b078134f48552c4d9527db2f7da0b5359abd49393cdf9794017baec7506170",
-                "sha256:eb6dce402734575e1a8cc0bb1509afca508a400a57ce13d306ea2c663bad1138",
-                "sha256:f1790a4b1e8e8e028c391175433b9c8122c39b46e1663228158e61e6f915bf06",
-                "sha256:f5efe0661b9fcd6246f27957f6ae1c0eb29bc60552820f01e970b4996e016004",
-                "sha256:f9cbfbc5faca235fbdf531b93aa0f9f005ec7d267d9d738761a4d42b744ea159",
-                "sha256:fbea1751729afe607d84acfd01efd95e3b31db148a181a441984ce9b3d3469da",
-                "sha256:fca4b4307ebe9c3ec77a084da3a9d1999d164693d16492ca2b64594340999988",
-                "sha256:ff5c6771c7e3511a06555afa317879b7db8d640137ba55d6ab0d0c50425cab75"
+                "sha256:0c8e589379ef0407b10bed16cc26e7392ef8f86961a706ade0a22309a45414d7",
+                "sha256:0d41c684f286ce41fa05ab6af70f32d6da1b6f0457459a56cf9e393c1c0b2217",
+                "sha256:1056cadd5e850a1c026f28e0704ab0a94daaa8f887ece8dfed30f88befb87bb0",
+                "sha256:11d86c6145ac5c706c53d484784cf504d7d10fa407cb73b9d20f09ff986059ef",
+                "sha256:170ed4971bf9058582b01a8338605f4d8c849bd88834061e60e83b52d0c76870",
+                "sha256:17791acaa0c0f89323c57da7b9a79f2174e26d5debbc8c02d84ebd80c2b7bff8",
+                "sha256:17931dfbb84ae18b287279c1f92b76a3abcd9a49cd69b92e946035cff06bcd20",
+                "sha256:18662443c6c3707e2fc7fad184b4dc32dd428710bbe72e1bce7fe1988d4aa654",
+                "sha256:187df91395c11e9f9dc69b38d12406df85aa5865f1766a47907b1cc9855b6303",
+                "sha256:1fee66b32e79264f428dc8da18396ad59cc48eef3c9c13844adec890cd339db5",
+                "sha256:2270d590997445a0dc29afa92e5534bfea76ba3aea026289e811bf9ed4b65a7f",
+                "sha256:2654caaf5584449d49c94a6b382b3cb4a246c090e72453493ea168b931206a4d",
+                "sha256:26bfb6226e0c157af5da16d2d62258f1ac578d2899130a50433ffee4a5dfa673",
+                "sha256:2941756754a10e799e5b87e2319bbec481ed0957421fba0e7b9fb1c11e40509f",
+                "sha256:3294f787a437cb5d81846de3a6697f0c35ecff37a932d73b1fe62490bef69211",
+                "sha256:358dc7ddf25e79e1cc8ee16d970c23faee84d532b873519c5036dbb858965795",
+                "sha256:38bc4ed5cae853409cb193c87c86cd0bc8d3a70fd2268a9807217b9176093ac6",
+                "sha256:3a0baff7827a632204060f48dca9e63fbd6a5a0b8790c1a2adfb25dc2c9c0d50",
+                "sha256:3a3ede8c248f36b60227eb777eac1dbc2f1022dc4d741b177c4379ca8e75571a",
+                "sha256:3a58a2f2ca7aaf22b265388d40232f453f67a6def7355a840b98c2d547bd037f",
+                "sha256:4434b739a8a101a837caeaa0137e0e38cb4ea561f39cb8960f3b1e7f4967a3fc",
+                "sha256:460024cacfc3246cc4d9f47a7fc860e4fcea7d1dc651e1256510d8c3c9c7cde0",
+                "sha256:46c465ad06971abcf46dd532f77560181387b4eea59084434bdff97524444032",
+                "sha256:48e424347a45568413deec6f6ee2d720de2cc0385019bedf44cd93e8638aa0ed",
+                "sha256:4a8c83f6fcdc327783bdc737e8e45b2e909b7bd108c4da1892d3bc59c04a6d84",
+                "sha256:4c840cc11163d3c01a9d8aad227683c48cd3e5be5a785921bcc2a8b4b758c4f3",
+                "sha256:4d486ddcaca8c68455aa01cf53d28d413fb41a35afc9f6594a730c9779545876",
+                "sha256:4e76381be3d8ff96a4e6c77815653063e87555981329cf8f85e5be5abf449021",
+                "sha256:50d866f7b1a3f16f98603e095f24c0eeba25eb508c85a2c5939c8b3870ba2df8",
+                "sha256:52492b87d5877ec405542f43cd3da80bdcb2d0c2fbc73236526e5f2c28e6db28",
+                "sha256:56afb44a12b0864d17b597210d63a5b88915d680f6484d8d202ed68ade38673d",
+                "sha256:585ce7cd97be8f538345de47b279b879e091c8b86d9dbc6d98a96a7ad78876a3",
+                "sha256:5870d620b23b956f72bafed6a0ba9a62edb5f2ef78a8849b7615bd9433384171",
+                "sha256:5c6ea72fe619fee5e6b5d4040a451d45d8175f560b11b3d3e044cd24b2720526",
+                "sha256:688058e89f512fb7541cb85c2f149c292d3fa22f981d5a5453b40c5da49eb9e8",
+                "sha256:6a3f47930fbbed0f6377639503848134c4aa25426b08778d641491131351c2c8",
+                "sha256:6b981316fcd940f085f646b822c2ff2b8b813cbd61281acad229ea3cbaabeb6b",
+                "sha256:734144cd2bd633a1516948e477ff6c835041c0536cef1d5b9a823ae29899665b",
+                "sha256:736bb076f7299c5c55dfef3eb9e96071a795cb08052822c2bb349b06f4cb2e0a",
+                "sha256:752485cbbb50c1e20908450ff4f94217acba9358ebdce0d8106510859d6eb19a",
+                "sha256:753eaaa0c7195244c84b5cc159dc8204b7fd99f716f11198f999f2332a86b178",
+                "sha256:75ac158560dec3ed72f6d604c81090ec44529cfb8169b05ae6fcb3e986b325d9",
+                "sha256:76499469dcc24759399accd85ec27f237d52dec300daaca46a5352fcbebb1071",
+                "sha256:782ca9c58f5c491c7afa55518542b2b005caedaf4685ec814fadfcee51f02493",
+                "sha256:792155279dc093839e43f85ff7b9b6493a8eaa0af1f94f1f9c6e8f4de8c63500",
+                "sha256:7a1606ba68e311576bcb1672b2a1543417e7e0aa4c85e9e718ba6466952476c0",
+                "sha256:8281db240a1616af2f9c5f71d355057e73a1409c4648c8949901396dc0a3c151",
+                "sha256:871e1b47eec7b6df76b23c642a81db5dd6536cbef26b7e80e7c56c2fd371382e",
+                "sha256:8b9c4643e7d843a0dca9cd9d610a0876e90a1b2cbc4c5ba7930a0d90baf6903f",
+                "sha256:8c6d5fed96f0646bfdf698b0a1cebf32b8aae6892d1bec0c5d2d6e2df44e1e2d",
+                "sha256:8e1bf59e035534ba4077f5361d8d5d9194149f9ed4f823d1ee29ef3e8964ace3",
+                "sha256:8fd51299e21da709eabcd5b2dd60e39090804431292daacbee8d3dabe39a6bc0",
+                "sha256:91c012dceadc695ccf69301bfdccd1fc4472ad714fe2dd3c5ab4d2046afddf29",
+                "sha256:93771146ef048b34201bfa382c2bf74c524980870bb278e6df515efaf93699ff",
+                "sha256:93d1c8cc5bf5df401015c5e2a3ce75a5254a9839e5039c881365d2a9dcfc6dc2",
+                "sha256:9611b83810a74a46be88847e0ea616794c406dbcb4e25405e52bff8f4bee2d0a",
+                "sha256:9bc27dd5cfdbe3dc7f381b05e6260ca6da41931a6e582267d5ca540270afeeb2",
+                "sha256:ac8eda86cc75859093e9ce390d423aba968f50cf0e481e6c7d7d63f90bae5c9c",
+                "sha256:bc3003710e335e3f842ae3fd78efa55f11a863a89a72e9a07da214db3bf7e1f8",
+                "sha256:bc61b005f6521fcc00ca0d1243559a5850b9dd1e1fe07b891410ee8fe192d0c0",
+                "sha256:be4c7b1c49d9917c6e95258d3d07f43cfba2c69a6929816e77daf322aaba6628",
+                "sha256:c019abc2eca67dfa4d8fb72ba924871d764ec3c92b86d5b53b405ad3d6aa56b0",
+                "sha256:c42774d1d1508ec48c3ed29e7b110e33f5e74a20957ea16197dbcce8be6b52ba",
+                "sha256:c556fbc6820b6e2cda1ca675c5fa5589cf188f8da6b33e9fc05b002e603e44fa",
+                "sha256:c6e659b9a24d145e271c2faf3fa6dd1fcb3e5d3f4e17273d9e0350b6ab0fe6e2",
+                "sha256:c74f0b0472ac40b04e6d28532f55cac8090e34c3e81f118d12843e6df14d0909",
+                "sha256:cd7e35818d2328b679a13268d9ea505c85cd773572ebb7a0da7ccbca77b6a52e",
+                "sha256:d17832ba39374134c10e82d137e372b5f7478c4cceeb19d02ae3e3d1daed8721",
+                "sha256:d1fa68a3c921365c5745b4bd3af6221ae1f0ea1bf04b69e94eda60e57958907f",
+                "sha256:d63123bfd0dce5f91101e77c8a5427c3872501acece8c90df457b486bc1acd47",
+                "sha256:da9d3061e61e5ae3f753654813bc1cd1c70e02fb72cf871bd6daf78443e9e2b1",
+                "sha256:db5ac3871ed76340210fe028f535392f097fb31b875354bcb69162bba2632ef4",
+                "sha256:dd7abf4f717e33b7487121faf23560b3a50924f80e4bef62b22dab441ded8f3b",
+                "sha256:dd90238d3a77a0e07d4d6ffdebc0c21a9787c5953a508a2231b5f191455f31e9",
+                "sha256:ef6eee1a61638d29cd7c85f7fd3ac7b22b4c0fabc8fd00a712b727a3e73b0685",
+                "sha256:f11fd61d72d93ac23718d393d2a64469af40be2116b24da0a4ca6922df26807e",
+                "sha256:f1e7fedb09c059efee2533119666ca7e1a2610072076926fa028c2ba5dfeb78c",
+                "sha256:f25b7e93f5414b9a983e1a6c1820142c13e1782cc9ed354c25e933aebe97fcf2",
+                "sha256:f2f44a4247461965fed18b2573f3a9eb5e2c3cad225201ee858726cde610daca",
+                "sha256:f5ffc6b7ace5b22d9e73b2a4c7305740a339fbd55301d52735f73e21d9eb3130",
+                "sha256:ff6af03cac0d1a4c3c19e5dcc4c05252411bf44ccaa2485e20d0a7c77892ab6e",
+                "sha256:ff8d95e06546c3a8c188f68040e9d0360feb67ba8498baf018918f669f7bc39b"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.17.1"
+            "version": "==1.17.2"
         },
         "zipp": {
             "hashes": [


### PR DESCRIPTION
This PR reverts #19, and hopefully the change in dependabot configuration can solve the problem of not updating `Pipfile.lock` (when there are no changes needed in `Pipfile`). Also I think `peft` is no longer needed with the current stable version of `FlagEmbedding`.