### PR TITLE
chore: disaggregate makefile targets and lower dependabot workload

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,8 +21,6 @@ updates:
       interval: daily
     labels:
       - dependencies
-    allow:
-      - dependency-type: all
     groups:
       all:
         patterns:

--- a/app/Makefile
+++ b/app/Makefile
@@ -7,35 +7,59 @@ run:
 	docker-compose up
 
 # [DEV] Update lock files and development environment on the host machine
-devlock:
+devlockbackend:
 	@cd backend && pipenv lock && pipenv sync -d && pipenv clean
+devlockfrontend:
 	@cd frontend && pnpm install
+devlock:
+	@$(MAKE) devlockbackend
+	@$(MAKE) devlockfrontend
 
 # [DEV] Install development dependencies on the host machine based on the lock
 # files without modifying them
-devinstall:
+devinstallbackend:
 	@cd backend && pipenv sync -d
+devinstallfrontend:
 	@cd frontend && pnpm install --frozen-lockfile
+devinstall:
+	@$(MAKE) devinstallbackend
+	@$(MAKE) devinstallfrontend
 
 # [DEV] Format and lint the codebase
-devlint:
+devlintbackend:
 	@cd backend && pipenv run bash -c "black . && ruff check --select I --fix . && ruff format . && mypy ."
+devlintfrontend:
 	@cd frontend && pnpm format && pnpm lint
+devlint:
+	@$(MAKE) devlintbackend
+	@$(MAKE) devlintfrontend
 
 # [DEV] Check formatting and linting of the codebase
-devlintcheck:
+devlintcheckbackend:
 	@cd backend && pipenv run bash -c "black --check . && ruff check --select I . && mypy ."
+devlintcheckfrontend:
 	@cd frontend && pnpm format:check && pnpm lint:check
+devlintcheck:
+	@$(MAKE) devlintcheckbackend
+	@$(MAKE) devlintcheckfrontend
 
 # [DEV] Test the codebase
-devtest:
+devtestbackend:
 	@cd backend && pipenv run pytest
+devtestfrontend:
 	@cd frontend && pnpm test
+devtest:
+	@$(MAKE) devtestbackend
+	@$(MAKE) devtestfrontend
 
 # [DEV] Test the codebase and generate coverage reports
-devtestcov:
+devtestcovbackend:
 	@cd backend && pipenv run bash -c "coverage run -m pytest && coverage report -m && coverage html"
+devtestcovfrontend:
 	@cd frontend && pnpm test:cov
+devtestcov:
+	@$(MAKE) devtestcovbackend
+	@$(MAKE) devtestcovfrontend
 
 # [DEV] Run the backend server only; this should be run in a separate terminal
 # window before running `devfrontend`


### PR DESCRIPTION
This makes the two changes as described in the title. For the former, see https://github.com/VeritasTrial/ac215_VeritasTrial/pull/23#issuecomment-2484968278, essentially it is disaggregating frontend and backend commands so that macOS developers can run frontend targets only (if they cannot get backend environment properly set up locally). For the latter, it was initially because of #20 but it did not solve the problem so reverting back to default (which is much faster).