### PR TITLE
ci(test): extend backend test suite except for the chat endpoint

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -34,7 +34,7 @@ CHROMADB_COLLECTION: chromadb.Collection | None = None
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI):  # pragma: no cover
     """Context manager to handle the lifespan of the FastAPI app."""
     global EMBEDDING_MODEL, CHROMADB_COLLECTION
     EMBEDDING_MODEL = FlagModel("BAAI/bge-small-en-v1.5", use_fp16=True)
@@ -61,7 +61,7 @@ app.add_middleware(
 )
 
 
-def custom_openapi():
+def custom_openapi():  # pragma: no cover
     """OpenAPI schema customization."""
     if app.openapi_schema:
         return app.openapi_schema
@@ -83,7 +83,9 @@ app.openapi = custom_openapi  # type: ignore
 
 
 @app.exception_handler(Exception)
-async def custom_exception_handler(request: Request, exc: Exception):
+async def custom_exception_handler(
+    request: Request, exc: Exception
+):  # pragma: no cover
     """Custom handle for all types of exceptions."""
     response = JSONResponse(
         status_code=500,

--- a/app/backend/test_main.py
+++ b/app/backend/test_main.py
@@ -1,5 +1,6 @@
 """Test the main module."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from main import app
@@ -11,4 +12,35 @@ def test_heartbeat():
     """Test the /heartbeat endpoint."""
     response = client.get("/heartbeat")
     assert response.status_code == 200
-    assert "timestamp" in response.json()
+    response_json = response.json()
+    assert "timestamp" in response_json
+
+
+@pytest.mark.parametrize("top_k", [1, 3, 5])
+def test_retrieve(top_k):
+    """Test the /retrieve endpoint."""
+    response = client.get(f"/retrieve?query=Dummy Query&top_k={top_k}")
+    assert response.status_code == 200
+    response_json = response.json()
+    assert "ids" in response_json
+    assert "documents" in response_json
+    assert len(response_json["ids"]) == top_k
+    assert len(response_json["documents"]) == top_k
+
+
+@pytest.mark.parametrize("top_k", [0, 31])
+def test_retrieve_invalid_top_k(top_k):
+    """Test the /retrieve endpoint with invalid top_k."""
+    response = client.get(f"/retrieve?query=Dummy Query&top_k={top_k}")
+    assert response.status_code == 404
+    assert "Required 0 < top_k <= 30" in response.text
+
+
+@pytest.mark.parametrize("item_id", ["id0", "id1", "id2"])
+def test_meta(item_id):
+    """Test the /meta/{item_id} endpoint."""
+    response = client.get(f"/meta/{item_id}")
+    assert response.status_code == 200
+    response_json = response.json()
+    assert "metadata" in response_json
+    assert response_json["metadata"]["shortTitle"] == f"Sample Metadata {item_id}"

--- a/app/backend/test_utils.py
+++ b/app/backend/test_utils.py
@@ -30,7 +30,7 @@ def test_format_exc_details():
         assert 'np.sum("")' in details
 
 
-@pytest.mark.parametrize("item_id", ["id1", "id2", "id3", "id4"])
+@pytest.mark.parametrize("item_id", ["id0", "id1", "id2"])
 def test_get_metadata_from_id(item_id, chromadb_collection, sample_metadata):
     metadata = get_metadata_from_id(chromadb_collection, item_id)
     assert metadata["shortTitle"] == f"Sample Metadata {item_id}"


### PR DESCRIPTION
This is the coverage report after this PR. Line 151-188 in `main.py` is the `/chat` endpoint, which will be modified shortly and tests should be added then. Note the coverage already reaches the required threshold of 50% for MS4, even without the `#pragma: no cover` lines in `main.py`.

```
Name             Stmts   Miss  Cover   Missing
----------------------------------------------
conftest.py         39      1    97%   119
localtyping.py      66      0   100%
main.py             63     17    73%   110, 112, 130, 139, 143, 151-188
test_main.py        30      0   100%
test_utils.py       32      0   100%
utils.py            22      2    91%   17, 123
----------------------------------------------
TOTAL              252     20    92%
```