### PR TITLE
ci: remove frontend tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,5 +53,3 @@ jobs:
         with:
           name: backend-coverage-report
           path: app/backend/htmlcov/
-
-      # TODO: Upload frontend coverage report once implemented

--- a/app/Makefile
+++ b/app/Makefile
@@ -43,23 +43,14 @@ devlintcheck:
 	@$(MAKE) devlintcheckbackend
 	@$(MAKE) devlintcheckfrontend
 
-# [DEV] Test the codebase
-devtestbackend:
-	@cd backend && pipenv run pytest
-devtestfrontend:
-	@cd frontend && pnpm test
+# [DEV] Test the codebase; note we are only testing the backend
 devtest:
-	@$(MAKE) devtestbackend
-	@$(MAKE) devtestfrontend
+	@cd backend && pipenv run pytest
 
-# [DEV] Test the codebase and generate coverage reports
-devtestcovbackend:
-	@cd backend && pipenv run bash -c "coverage run -m pytest && coverage report -m && coverage html"
-devtestcovfrontend:
-	@cd frontend && pnpm test:cov
+# [DEV] Test the codebase and generate coverage reports; note we are only
+# testing the backend
 devtestcov:
-	@$(MAKE) devtestcovbackend
-	@$(MAKE) devtestcovfrontend
+	@cd backend && pipenv run bash -c "coverage run -m pytest && coverage report -m && coverage html"
 
 # [DEV] Run the backend server only; this should be run in a separate terminal
 # window before running `devfrontend`

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -11,9 +11,7 @@
     "format": "prettier --write .",
     "lint:check": "eslint .",
     "lint": "eslint --fix .",
-    "preview": "vite preview",
-    "test": "echo \"Frontend testing not implemented\"",
-    "test:cov": "echo \"Frontend testing not implemented\""
+    "preview": "vite preview"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",


### PR DESCRIPTION
We will not include a frontend test suite at least for now. A previous attempt was in #27.