### PR TITLE
ci: extend dependabot to also update the pipeline

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,10 @@ updates:
   - package-ecosystem: pip
     directories:
       - /app/backend
+      - /src/data-pipeline
+      - /src/embedding-model
+      - /src/construct-qa
+      - /src/finetune-model
     schedule:
       interval: daily
     labels:

--- a/src/embedding-model/Dockerfile
+++ b/src/embedding-model/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONBUFFERED=1
 RUN set -ex; \
   apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y build-essential curl && \
+  apt-get install -y build-essential curl zlib1g-dev && \
   rm -rf /var/lib/apt/lists/* && \
   pip install --no-cache-dir --upgrade pip && \
   pip install --no-cache-dir pipenv


### PR DESCRIPTION
Though we are not making the pipeline part (`src/`) very robust (and may not do so in the future either), we may still keep things up-to-date (since it is easy). The update frequency can be lowered when the course project ends, or maybe we can fully disable dependabot by then.