### PR TITLE
cd: deploy chromadb with terraform

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -26,4 +26,4 @@ jobs:
         run: cd deploy && make build
 
       - name: Deploy app
-        run: cd deploy && make gh-actions
+        run: cd deploy && make gh-actions command=./deploy-app.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ dist/
 *.tsbuildinfo
 .coverage
 
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+
 # Data files
 data/
 

--- a/deploy/.dockerignore
+++ b/deploy/.dockerignore
@@ -1,0 +1,3 @@
+chromadb/.terraform/
+chromadb/*.tfstate
+chromadb/*.tfstate.backup

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,6 +19,16 @@ RUN set -ex; \
   apt-get update && \
   apt-get install -y google-cloud-cli
 
+# Install Terraform
+# https://developer.hashicorp.com/terraform/install?product_intent=terraform#linux
+RUN set -ex; \
+  curl -fsSL https://apt.releases.hashicorp.com/gpg | \
+    gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+    tee /etc/apt/sources.list.d/hashicorp.list && \
+  apt-get update && \
+  apt-get install -y terraform
+
 # Install Docker
 # https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 RUN set -ex; \
@@ -41,7 +51,7 @@ RUN set -ex; \
 # Install Ansible
 RUN set -ex; \
   python3.11 -m pip install requests ansible && \
-  ansible-galaxy collection install community.docker
+  ansible-galaxy collection install community.docker google.cloud
 
 # Clean up
 RUN set -ex; \

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -9,17 +9,18 @@ all: build
 build:
 	$(DOCKER_CMD) build -t $(IMAGE_NAME) .
 
-# Run the Docker container and enter its interactive shell
+# Run the Docker container and enter its interactive shell, or run a command
 run:
-	$(DOCKER_CMD) container run -it --rm \
+	$(DOCKER_CMD) container run $(if $(command),,-it) --rm \
 		--env GOOGLE_APPLICATION_CREDENTIALS=/secrets/veritas-trial-deployment.json \
 		--env GCP_PROJECT_ID=veritastrial \
 		--env GCP_REGION=us-central1 \
+		--env GCP_ZONE=us-central1-a \
 		--volume $(PWD)/../secrets/veritas-trial-deployment.json:/secrets/veritas-trial-deployment.json:ro \
 		--volume $(PWD)/../app/backend:/app/backend:ro \
 		--volume $(PWD)/../app/frontend:/app/frontend:ro \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
-		--name $(CONTAINER_NAME) $(IMAGE_NAME)
+		--name $(CONTAINER_NAME) $(IMAGE_NAME) $(command)
 
 # Used by Github Actions; NOTE: the GOOGLE_APPLICATION_CREDENTIALS environment
 # variable is set by the authentication action in the workflow and will be
@@ -29,10 +30,11 @@ gh-actions:
 		--env GOOGLE_APPLICATION_CREDENTIALS=/secrets/veritas-trial-deployment.json \
 		--env GCP_PROJECT_ID=veritastrial \
 		--env GCP_REGION=us-central1 \
+		--env GCP_ZONE=us-central1-a \
 		--volume $(GOOGLE_APPLICATION_CREDENTIALS):/secrets/veritas-trial-deployment.json:ro \
 		--volume $(PWD)/../app/backend:/app/backend:ro \
 		--volume $(PWD)/../app/frontend:/app/frontend:ro \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
-		--name $(CONTAINER_NAME) $(IMAGE_NAME) ./deploy-app.sh
+		--name $(CONTAINER_NAME) $(IMAGE_NAME) $(command)
 
 .PHONY: build run

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,14 +1,29 @@
 # Deploy
 
-The deployment is automated with GitHub Actions. The following explains the components for deployment, but one should never run them manually. Enter this directory, then build and run the container:
+Enter this directory, then build and run the container:
 
 ```bash
 make build
 make run
 ```
 
-Inside the container, run:
+## App
+
+The deployment uses Ansible. Inside the container:
 
 ```bash
-ansible-playbook app/deploy-images.yaml -i inventory.yaml  # Deploy app images
+./deploy-app.sh  # Deploy app images and K8S cluster
 ```
+
+The deployment command is automated with GitHub Actions. It is preferred to trigger the corresponding workflow instead of running the command manually.
+
+## ChromaDB
+
+The deployment uses Terraform, as suggested in [ChromaDB docs](https://docs.trychroma.com/deployment/gcp). Inside the container:
+
+```bash
+./deploy-chromadb.sh  # Deploy ChromaDB instance
+./destroy-chromadb.sh # Destroy ChromaDB instance
+```
+
+Both commands are not automated and need to be run manually when necessary.

--- a/deploy/chromadb/.terraform.lock.hcl
+++ b/deploy/chromadb/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.12.0"
+  hashes = [
+    "h1:rvZHMkoxkHrBYQXb/waoZiD2oo3FS1AF8HoWHlb6SN8=",
+    "zh:14701aa307a832d99f567b8056a4c5e4ee5a403d984c98f024deee7507a3f29c",
+    "zh:344eca00ffb2643c2fa7f52f069b659d50bb4c9369df4cad96ea0fadb54282c8",
+    "zh:5fb57c0acfd4d30a39941900040d5518a909d8c975af0c4366a7bfd0d0bb09a8",
+    "zh:617a77048a5b9aa568e8bc706cc84307a237b2dd0e49709028b283f8bbe42475",
+    "zh:677837a05fefe0342cf4d4bdc494e8fd4d62331cac947820e73df37e8f512688",
+    "zh:7b79f6e02474eef4a1480fc6589afb63ed16b25bf019b6056f9838e2845e2ef8",
+    "zh:7d891fceb5b15e81240d829f42e1a36e4c812bfc1abe7856756e59101932205f",
+    "zh:97f1e0ac799faf382426e070e888fac36b0867597b460dc95b0e7f657de21ba9",
+    "zh:9855f2f2f5919ff6a6a2c982439c910d28c8978ad18cd8f549a5d1ba9b4dc4c3",
+    "zh:ac551367180eb396af2a50244e80243d333d600a76002e29935262d76a02290b",
+    "zh:c354f34e6579933d21a98ce7f31f4ef8aeaceb04cfaedaff6d3f3c0be56b2c79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/chromadb/chroma.tfvars
+++ b/deploy/chromadb/chroma.tfvars
@@ -1,0 +1,6 @@
+chroma_version = "0.5.20"
+project_id="veritastrial"
+region="us-central1"
+zone="us-central1-a"
+instance_name = "veritas-trial-chromadb"
+machine_type = "n2d-standard-2"

--- a/deploy/chromadb/main.tf
+++ b/deploy/chromadb/main.tf
@@ -1,0 +1,150 @@
+# This file is copied from:
+# https://github.com/chroma-core/chroma/blob/155cf7b36cfeb68f3a3446b677072ae107eece27/deployments/gcp/main.tf
+
+# Variables
+variable "project_id" {
+  description = "GCP Project ID"
+}
+
+variable "region" {
+  description = "GCP Region"
+}
+
+variable "zone" {
+  description = "GCP Zone"
+}
+
+variable "instance_name" {
+  description = "Name of the Compute Engine instance"
+  default     = "chroma-instance"
+}
+
+variable "machine_type" {
+  description = "Compute Engine machine type"
+  default     = "e2-small"
+}
+
+variable "chroma_version" {
+  description = "Chroma version to install"
+  default     = "0.5.22"
+}
+
+variable "chroma_server_auth_credentials" {
+  description = "Chroma authentication credentials"
+  default     = ""
+}
+
+variable "chroma_server_auth_provider" {
+  description = "Chroma authentication provider"
+  default     = ""
+}
+
+variable "chroma_auth_token_transport_header" {
+  description = "Chroma authentication custom token header"
+  default     = ""
+}
+
+variable "chroma_otel_collection_endpoint" {
+  description = "Chroma OTEL endpoint"
+  default     = ""
+}
+
+variable "chroma_otel_service_name" {
+  description = "Chroma OTEL service name"
+  default     = ""
+}
+
+variable "chroma_otel_collection_headers" {
+  description = "Chroma OTEL headers"
+  default     = "{}"
+}
+
+variable "chroma_otel_granularity" {
+  description = "Chroma OTEL granularity"
+  default     = ""
+}
+
+# Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+# Firewall Rule
+resource "google_compute_firewall" "default" {
+  name    = "chroma-allow-ssh-http"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "8000"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# Compute Engine Instance
+resource "google_compute_instance" "chroma_instance" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+      size  = 24
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  metadata_startup_script = <<-EOT
+  #!/bin/bash
+  USER=chroma
+  useradd -m -s /bin/bash $USER
+  apt-get update
+  apt-get install -y docker.io
+  usermod -aG docker $USER
+  curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  systemctl enable docker
+  systemctl start docker
+
+  mkdir -p /home/$USER/config
+  curl -o /home/$USER/docker-compose.yml https://s3.amazonaws.com/public.trychroma.com/cloudformation/assets/docker-compose.yml
+  sed -i "s/CHROMA_VERSION/${var.chroma_version}/g" /home/$USER/docker-compose.yml
+
+  # Create .env file
+  echo "CHROMA_SERVER_AUTHN_CREDENTIALS=${var.chroma_server_auth_credentials}" >> /home/$USER/.env
+  echo "CHROMA_SERVER_AUTHN_PROVIDER=${var.chroma_server_auth_provider}" >> /home/$USER/.env
+  echo "CHROMA_AUTH_TOKEN_TRANSPORT_HEADER=${var.chroma_auth_token_transport_header}" >> /home/$USER/.env
+  echo "CHROMA_OTEL_COLLECTION_ENDPOINT=${var.chroma_otel_collection_endpoint}" >> /home/$USER/.env
+  echo "CHROMA_OTEL_SERVICE_NAME=${var.chroma_otel_service_name}" >> /home/$USER/.env
+  echo "CHROMA_OTEL_COLLECTION_HEADERS=${var.chroma_otel_collection_headers}" >> /home/$USER/.env
+  echo "CHROMA_OTEL_GRANULARITY=${var.chroma_otel_granularity}" >> /home/$USER/.env
+
+  chown $USER:$USER /home/$USER/.env /home/$USER/docker-compose.yml
+  cd /home/$USER
+  sudo -u $USER docker-compose up -d
+EOT
+
+
+  # Tags for firewall rules
+  tags = ["chroma-server"]
+
+  # Service account with necessary scopes
+  service_account {
+    scopes = ["cloud-platform"]
+  }
+}
+
+# Output
+output "chroma_instance_ip" {
+  description = "Public IP address of the Chroma server"
+  value       = google_compute_instance.chroma_instance.network_interface[0].access_config[0].nat_ip
+}

--- a/deploy/deploy-app.sh
+++ b/deploy/deploy-app.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# This script is used by GitHub Actions
 ansible-playbook app/deploy-images.yaml -i inventory.yaml

--- a/deploy/deploy-chromadb.sh
+++ b/deploy/deploy-chromadb.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+cd chromadb
+terraform init
+
+terraform import \
+  -var-file chroma.tfvars \
+  google_compute_instance.chroma_instance \
+  veritastrial/us-central1-a/veritas-trial-chromadb || true
+terraform import \
+  -var-file chroma.tfvars \
+  google_compute_firewall.default \
+  veritastrial/chroma-allow-ssh-http || true
+
+terraform apply -var-file chroma.tfvars
+terraform output -raw chroma_instance_ip

--- a/deploy/destroy-chromadb.sh
+++ b/deploy/destroy-chromadb.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+cd chromadb
+terraform init
+
+terraform import \
+  -var-file chroma.tfvars \
+  google_compute_instance.chroma_instance \
+  veritastrial/us-central1-a/veritas-trial-chromadb || true
+terraform import \
+  -var-file chroma.tfvars \
+  google_compute_firewall.default \
+  veritastrial/chroma-allow-ssh-http || true
+
+terraform destroy -var-file chroma.tfvars

--- a/deploy/inventory.yaml
+++ b/deploy/inventory.yaml
@@ -1,7 +1,10 @@
 all:
   vars:
+    google_application_credentials: "{{ lookup('env', 'GOOGLE_APPLICATION_CREDENTIALS') }}"
     gcp_project_id: "{{ lookup('env', 'GCP_PROJECT_ID') }}"
     gcp_region: "{{ lookup('env', 'GCP_REGION') }}"
+    gcp_zone: "{{ lookup('env', 'GCP_ZONE') }}"
+    gcp_auth_kind: serviceaccount
     frontend_name: veritas-trial-frontend
     backend_name: veritas-trial-backend
 


### PR DESCRIPTION
This PR follows the guide here: https://docs.trychroma.com/deployment/gcp

The decision is to deploy ChromaDB separate from the K8S cluster, because K8S is better suited for managing stateless services while the database is stateful. The given tutorial recreates the database every time it creates or updates the K8S cluster, which is not suitable in our case as our vector database needs to be managed by an external program and involves huge costly computation (or requires GPU).

As stated in README, `./deploy-chromadb.sh` deploys the instance or updates the instance. `./destroy-chromadb.sh` destroys the instance.