### PR TITLE
fix/cd: git proper permissions to update docker tag

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -35,6 +35,8 @@ jobs:
           rm /tmp/veritas-trial-service.json
 
       - name: Update Docker tag
+        permissions:
+          contents: write
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
See https://github.com/VeritasTrial/ac215_VeritasTrial/actions/runs/12179317173, the pushing step failed. The default permissions is read-only, so we need to specify a scoped permission to write to the repository.