### PR TITLE
cd: cannot auto delete branch on auto merge; we need to manually delete

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -53,7 +53,7 @@ jobs:
             Check the workflow run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Enable auto-merge
-        run: gh pr merge --squash --auto --delete-branch "$PR_NUMBER"
+        run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
The `--delete-branch` tag has no effect when used with `--auto`. We simply remove it. This means that we need to remember to manually delete the branch created by the workflow for the PRs.