### PR TITLE
fix/ci: fix wrong branch configuration when creating pr in deploy workflow

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -42,7 +42,6 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
           labels: app, ci/cd
           title: "cd: Update Docker tag for app"
           commit-message: "cd: Update Docker tag for app"


### PR DESCRIPTION
This is likely a typo. We can just let the action determine the base (by default the branch checked out in the workflow) and the PR branch (it will automatically choose a name).