### PR TITLE
cd: update chromadb instance image version

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -41,7 +41,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CHARLIE_XIAO_PAT }}
           labels: app, ci/cd
           title: "cd: Update Docker tag for app"
           commit-message: "cd: Update Docker tag for app"
@@ -54,5 +54,5 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CHARLIE_XIAO_PAT }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,4 +27,4 @@ The deployment uses Terraform, as suggested in [ChromaDB docs](https://docs.tryc
 ./destroy-chromadb.sh # Destroy ChromaDB instance
 ```
 
-Both commands are not automated and need to be run manually when necessary.
+Both commands are not automated and need to be run manually when necessary. After a new deployment, one must update the `CHROMADB_HOST` environment variable in the "Create backend deployment" step in `app/deploy-k8s.yaml` and trigger the app deployment workflow.

--- a/deploy/app/deploy-k8s.yaml
+++ b/deploy/app/deploy-k8s.yaml
@@ -157,7 +157,7 @@
                       - name: GOOGLE_APPLICATION_CREDENTIALS
                         value: /secrets/veritas-trial-service.json
                       - name: CHROMADB_HOST
-                        value: 35.188.136.220
+                        value: 35.226.13.117
                       - name: SERVER_ROOT_PATH
                         value: /api
 

--- a/deploy/chromadb/chroma.tfvars
+++ b/deploy/chromadb/chroma.tfvars
@@ -1,4 +1,4 @@
-chroma_version = "0.5.20"
+chroma_version = "0.5.23"
 project_id="veritastrial"
 region="us-central1"
 zone="us-central1-a"

--- a/deploy/deploy-chromadb.sh
+++ b/deploy/deploy-chromadb.sh
@@ -15,4 +15,3 @@ terraform import \
   veritastrial/chroma-allow-ssh-http || true
 
 terraform apply -var-file chroma.tfvars
-terraform output -raw chroma_instance_ip


### PR DESCRIPTION
New chroma image was release a few hours ago (0.5.23). I have redeployed the VM and updated the IP. This PR also switches to use `CHARLIE_XIAO_PAT` instead of `GITHUB_TOKEN` so that workflows can be triggered on the PR created by the workflow.