### PR TITLE
fix: unpin chromadb collection in the backend

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-rebuild-images:
-        description: Whether to skip rebuilding images
+        description: Skip rebuilding images
         required: false
         type: boolean
         default: true

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -58,6 +58,7 @@ jobs:
             Check the workflow run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Enable auto-merge
+        if: ${{ steps.create-pr.outputs.pull-request-number != '' }}
         run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.CHARLIE_XIAO_PAT }}

--- a/.github/workflows/deploy-chromadb.yaml
+++ b/.github/workflows/deploy-chromadb.yaml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       skip-rebuild-images-app:
-        description: Whether to skip rebuilding images for app deployment
+        description: Skip rebuilding app images
         required: false
         type: boolean
         default: true
       skip-rebuild-images-pipeline:
-        description: Whether to skip rebuilding images for pipeline deployment
+        description: Skip rebuilding pipeline images
         required: false
         type: boolean
         default: true

--- a/.github/workflows/deploy-chromadb.yaml
+++ b/.github/workflows/deploy-chromadb.yaml
@@ -67,6 +67,7 @@ jobs:
             Check the workflow run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Enable auto-merge
+        if: ${{ steps.create-pr.outputs.pull-request-number != '' }}
         run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.CHARLIE_XIAO_PAT }}

--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-rebuild-images:
-        description: Whether to skip rebuilding images
+        description: Skip rebuilding images
         required: false
         type: boolean
         default: true

--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -58,6 +58,7 @@ jobs:
             Check the workflow run at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Enable auto-merge
+        if: ${{ steps.create-pr.outputs.pull-request-number != '' }}
         run: gh pr merge --squash --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.CHARLIE_XIAO_PAT }}

--- a/app/backend/conftest.py
+++ b/app/backend/conftest.py
@@ -107,6 +107,13 @@ class MockChromadbCollection:
         return self._result(ids, include)
 
 
+class MockChromadbClient:
+    """Mock ChromaDB client."""
+
+    def get_collection(self, name):
+        return MockChromadbCollection()
+
+
 @pytest.fixture
 def sample_metadata():
     """Return a fixed sample metadata."""
@@ -120,13 +127,13 @@ def embedding_model():
 
 
 @pytest.fixture
-def chromadb_collection():
-    """Return a mock ChromaDB collection."""
-    return MockChromadbCollection()
+def chromadb_client():
+    """Return a mock ChromaDB client."""
+    return MockChromadbClient()
 
 
 @pytest.fixture(autouse=True)
 def setup(monkeypatch):
     monkeypatch.setattr("vertexai.init", lambda: None)
     monkeypatch.setattr("main.EMBEDDING_MODEL", MockEmbeddingModel())
-    monkeypatch.setattr("main.CHROMADB_COLLECTION", MockChromadbCollection())
+    monkeypatch.setattr("main.CHROMADB_CLIENT", MockChromadbClient())

--- a/app/backend/test_utils.py
+++ b/app/backend/test_utils.py
@@ -31,8 +31,9 @@ def test_format_exc_details():
 
 
 @pytest.mark.parametrize("item_id", ["id0", "id1", "id2"])
-def test_get_metadata_from_id(item_id, chromadb_collection, sample_metadata):
-    metadata = get_metadata_from_id(chromadb_collection, item_id)
+def test_get_metadata_from_id(item_id, chromadb_client, sample_metadata):
+    collection = chromadb_client.get_collection("test")
+    metadata = get_metadata_from_id(collection, item_id)
     assert metadata["shortTitle"] == f"Sample Metadata {item_id}"
 
     for key, value in sample_metadata.items():


### PR DESCRIPTION
The update to the remote ChromaDB database deletes the original collection and creates a new one to avoid conflicts. Though they have the same name, they do not have the same ID, so if the backend cannot react to that change, it would have to be redeployed to function correctly (which is undesired). This PR tries to fix the problem by only pinning the ChromaDB client on backend startup and get the collection by name dynamically on request. This incurs some overhead on query but I think that's mostly negligible (especially since we theoretically have only one collection in the database), but I believe it can react to the database update without needing redeployment.

This also updates the cd workflows a bit, i.e., if skipping building images, there will be no changes, and thus no pr will be created, and thus the enable automerge step will fail and we want to avoid that (see https://github.com/VeritasTrial/ac215_VeritasTrial/actions/runs/12208650084).