### PR TITLE
fix: app devbackend target should connect to remove chromadb correctly

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -57,7 +57,7 @@ devtestcov:
 # [DEV] Run the backend server only; this should be run in a separate terminal
 # window before running `devfrontend`
 devbackend:
-	CHROMADB_HOST=$(CHROMADB_HOST) docker-compose up chromadb backend --build
+	CHROMADB_HOST=$(CHROMADB_HOST) docker-compose up backend --build
 
 # [DEV] Run the frontend in development mode; this should be run in a separate
 # terminal window when `devbackend` is running

--- a/app/Makefile
+++ b/app/Makefile
@@ -57,7 +57,7 @@ devtestcov:
 # [DEV] Run the backend server only; this should be run in a separate terminal
 # window before running `devfrontend`
 devbackend:
-	docker-compose up chromadb backend --build
+	CHROMADB_HOST=$(CHROMADB_HOST) docker-compose up chromadb backend --build
 
 # [DEV] Run the frontend in development mode; this should be run in a separate
 # terminal window when `devbackend` is running


### PR DESCRIPTION
I only updated the `build` and `run` target and forgot about the `devbackend` target. Two main changes: (1) there is no (and no need for) chromadb service locally, and (2) we should set the `CHROMADB_HOST` environment variable to make things work correctly.