### PR TITLE
chore: add devinstall target for all containers

### DIFF
--- a/src/construct-qa/Makefile
+++ b/src/construct-qa/Makefile
@@ -22,6 +22,12 @@ devlock:
 	pipenv sync -d
 	pipenv clean
 
+# [DEV] Install development dependencies on the host machine based on the lock
+# file without modifying it
+devinstall:
+	pipenv sync -d
+	pipenv clean
+
 # [DEV] Format the codebase
 devlint:
 	black .

--- a/src/data-pipeline/Makefile
+++ b/src/data-pipeline/Makefile
@@ -22,6 +22,12 @@ devlock:
 	pipenv sync -d
 	pipenv clean
 
+# [DEV] Install development dependencies on the host machine based on the lock
+# file without modifying it
+devinstall:
+	pipenv sync -d
+	pipenv clean
+
 # [DEV] Format the codebase
 devlint:
 	pipenv run bash -c "black . && ruff check --select I --fix . && ruff format . && mypy ."

--- a/src/embedding-model/Makefile
+++ b/src/embedding-model/Makefile
@@ -25,6 +25,12 @@ devlock:
 	pipenv sync -d
 	pipenv clean
 
+# [DEV] Install development dependencies on the host machine based on the lock
+# file without modifying it
+devinstall:
+	pipenv sync -d
+	pipenv clean
+
 # [DEV] Format the codebase
 devlint:
 	pipenv run bash -c "black . && ruff check --select I --fix . && ruff format . && mypy ."

--- a/src/finetune-model/Makefile
+++ b/src/finetune-model/Makefile
@@ -22,6 +22,12 @@ devlock:
 	pipenv sync -d
 	pipenv clean
 
+# [DEV] Install development dependencies on the host machine based on the lock
+# file without modifying it
+devinstall:
+	pipenv sync -d
+	pipenv clean
+
 # [DEV] Format the codebase
 devlint:
 	black .


### PR DESCRIPTION
This PR adds the `devinstall` target for all containers. This is mainly because we are now relying on dependabot for dependency updates, but `devlock` also modifies the lock file when installing the dependencies. One should, in most cases, use `devinstall`. Only when changing dependencies should one use `devlock`.