### PR TITLE
app: responsive design for the left sidebar

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -110,10 +110,6 @@ export const App = () => {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  useEffect(() => {
-    console.log("isSidebarPopoverVisible", isSidebarPopoverVisible);
-  }, [isSidebarPopoverVisible]);
-
   return (
     <Theme appearance={appearance} accentColor="indigo" grayColor="slate">
       <Toaster

--- a/app/frontend/src/components/ChatPanel.tsx
+++ b/app/frontend/src/components/ChatPanel.tsx
@@ -69,7 +69,7 @@ export const ChatPanel = ({
   const handleSend = async () => {
     setLoading(true);
     setQuery(""); // This will take effect only after the next render
-    addUserMessage(<RadixMarkdown text={query} size="2" />, query);
+    addUserMessage(<RadixMarkdown text={query} />, query);
 
     if (query === "/meta" || query === "/docs") {
       // Special commands where we only need to get metadata
@@ -105,10 +105,7 @@ export const ChatPanel = ({
         );
       } else {
         const data = callResult.payload;
-        addBotMessage(
-          <RadixMarkdown text={data.response} size="2" />,
-          data.response,
-        );
+        addBotMessage(<RadixMarkdown text={data.response} />, data.response);
       }
     }
 
@@ -124,11 +121,11 @@ export const ChatPanel = ({
     />,
     <FCDeleteChatButton key="delete-chat-button" onClick={deleteTab} />,
     <FCScrollButtons key="scroll-buttons" containerRef={chatPortRef} />,
-    <FCModelSelector key="model-selector" model={model} setModel={setModel} />,
   ];
 
   // Persistent right functional components
   const rightFCs = [
+    <FCModelSelector key="model-selector" model={model} setModel={setModel} />,
     <FCSendButton
       key="send-button"
       disabled={query === "" || loading}

--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -6,7 +6,7 @@
 
 import { Box, Flex, Heading, IconButton, Tooltip } from "@radix-ui/themes";
 import { Dispatch, SetStateAction } from "react";
-import { MdDarkMode, MdLightMode } from "react-icons/md";
+import { MdDarkMode, MdLightMode, MdMenu, MdMenuOpen } from "react-icons/md";
 import { FaGithub, FaUniversity } from "react-icons/fa";
 import { ApperanceType } from "../types";
 import { AC215_URL, GITHUB_URL } from "../consts";
@@ -15,9 +15,18 @@ import { ExternalLink } from "./ExternalLink";
 interface HeaderProps {
   appearance: ApperanceType;
   setAppearance: Dispatch<SetStateAction<ApperanceType>>;
+  isSidebarVisible: boolean;
+  isSidebarPopoverVisible: boolean;
+  setIsSidebarPopoverVisible: Dispatch<SetStateAction<boolean>>;
 }
 
-export const Header = ({ appearance, setAppearance }: HeaderProps) => {
+export const Header = ({
+  appearance,
+  setAppearance,
+  isSidebarVisible,
+  isSidebarPopoverVisible,
+  setIsSidebarPopoverVisible,
+}: HeaderProps) => {
   const switchAppearance = () => {
     if (appearance === "dark") {
       setAppearance("light");
@@ -28,8 +37,29 @@ export const Header = ({ appearance, setAppearance }: HeaderProps) => {
 
   return (
     <Flex justify="between" align="center" pr="3">
-      <Heading size="4">VeritasTrial</Heading>
+      <Box ml="2">
+        <Heading size="4">VeritasTrial</Heading>
+      </Box>
       <Flex align="center" gap="4">
+        {!isSidebarVisible && (
+          <Tooltip content="Toggle sidebar">
+            <Box>
+              <IconButton
+                size="1"
+                variant="ghost"
+                onClick={() =>
+                  setIsSidebarPopoverVisible(!isSidebarPopoverVisible)
+                }
+              >
+                {isSidebarPopoverVisible ? (
+                  <MdMenuOpen size="20" />
+                ) : (
+                  <MdMenu size="20" />
+                )}
+              </IconButton>
+            </Box>
+          </Tooltip>
+        )}
         <Tooltip content="Harvard AC215">
           <Box>
             <IconButton size="1" variant="ghost" asChild>

--- a/app/frontend/src/components/RadixMarkdown.tsx
+++ b/app/frontend/src/components/RadixMarkdown.tsx
@@ -33,7 +33,6 @@ import rehypeSanitize from "rehype-sanitize";
 
 interface RadixMarkdownProps {
   text: string;
-  size?: TextProps["size"];
 }
 
 const headingCss = {
@@ -48,9 +47,9 @@ const boxCss = {
   ":last-child": { marginBottom: 0 },
 };
 
-export const RadixMarkdown = ({ text, size }: RadixMarkdownProps) => {
+export const RadixMarkdown = ({ text }: RadixMarkdownProps) => {
   return (
-    <Text size={size} as="div">
+    <Text size="2" as="div">
       <Markdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw, rehypeSanitize]}
@@ -124,6 +123,7 @@ export const RadixMarkdown = ({ text, size }: RadixMarkdownProps) => {
             return (
               <Heading
                 as="h1"
+                size="5"
                 css={headingCss}
                 {...(rest as HeadingProps)}
               ></Heading>
@@ -134,6 +134,7 @@ export const RadixMarkdown = ({ text, size }: RadixMarkdownProps) => {
             return (
               <Heading
                 as="h2"
+                size="4"
                 css={headingCss}
                 {...(rest as HeadingProps)}
               ></Heading>
@@ -144,6 +145,7 @@ export const RadixMarkdown = ({ text, size }: RadixMarkdownProps) => {
             return (
               <Heading
                 as="h3"
+                size="3"
                 css={headingCss}
                 {...(rest as HeadingProps)}
               ></Heading>

--- a/app/frontend/src/components/RetrievePanel.tsx
+++ b/app/frontend/src/components/RetrievePanel.tsx
@@ -44,7 +44,7 @@ export const RetrievePanel = ({
   const handleSend = async () => {
     setLoading(true);
     setQuery(""); // This will take effect only after the next render
-    addUserMessage(<RadixMarkdown text={query} size="2" />, query);
+    addUserMessage(<RadixMarkdown text={query} />, query);
 
     const callResult = await callRetrieve(query, topK);
     if ("error" in callResult) {

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -37,7 +37,10 @@ export const Sidebar = ({
     <Flex direction="column" justify="between" height="100%">
       {/* Sidebar content */}
       <RadioCards.Root
-        css={{ height: "80%", gridTemplateRows: "auto auto 1fr" }}
+        css={{
+          height: "calc(100% - var(--space-9) - var(--space-3))",
+          gridTemplateRows: "auto auto 1fr",
+        }}
         size="1"
         variant="surface"
         columns="1"
@@ -97,26 +100,28 @@ export const Sidebar = ({
         </ScrollArea>
       </RadioCards.Root>
       {/* Sidebar footer */}
-      <ScrollArea scrollbars="vertical" asChild>
-        <Box height="auto" maxHeight="calc(20% - var(--space-4))">
-          <Flex direction="column" justify="end" gap="2" overflow="hidden">
-            <Button
-              size="2"
-              variant="surface"
-              color="red"
-              onClick={clearTabs}
-              disabled={metaMapping.size === 0}
-            >
-              <MdDeleteOutline size="20" /> Delete all chats
-            </Button>
-            <Text size="1" color="gray" as="div" align="center">
-              © 2024 <Link href="mailto:yaoxiao@g.harvard.edu">Yao Xiao</Link>,{" "}
-              <Link href="mailto:bowenxu@g.harvard.edu">Bowen Xu</Link>,{" "}
-              <Link href="mailto:tongxiao@g.harvard.edu">Tong Xiao</Link>
-            </Text>
-          </Flex>
-        </Box>
-      </ScrollArea>
+      <Flex
+        height="var(--space-9)"
+        direction="column"
+        justify="end"
+        gap="2"
+        overflow="hidden"
+      >
+        <Button
+          size="2"
+          variant="surface"
+          color="red"
+          onClick={clearTabs}
+          disabled={metaMapping.size === 0}
+        >
+          <MdDeleteOutline size="20" /> Clear chats
+        </Button>
+        <Text size="1" color="gray" as="div" align="center">
+          © 2024 <Link href="mailto:yaoxiao@g.harvard.edu">Yao Xiao</Link>,{" "}
+          <Link href="mailto:bowenxu@g.harvard.edu">Bowen Xu</Link>,{" "}
+          <Link href="mailto:tongxiao@g.harvard.edu">Tong Xiao</Link>
+        </Text>
+      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
This PR hides the left sidebar on small screen sizes (1024px) and instead adds a menu button to toggle the sidebar which is made as an overlay. Also, the left sidebar is made slightly wider between 1024px and 1280px screen widths.

![image](https://github.com/user-attachments/assets/cbae64bf-211d-4c95-8cf3-20a1dbacdda5)

![image](https://github.com/user-attachments/assets/b1bf48fe-4f37-4e6c-8652-3194f0f45afb)

Other changes: some minor layout adjustment, and fixed the heading sizes in markdown renderer.